### PR TITLE
Bug fix for banned users count

### DIFF
--- a/users/index.js
+++ b/users/index.js
@@ -181,7 +181,7 @@ users.pageModerators = function(opts) {
 users.count = function(opts) {
   var q = 'SELECT COUNT(u.id) FROM users u';
   if (opts && opts.filter && opts.filter === 'banned') {
-    q += ' RIGHT JOIN users.bans b ON (u.id = b.user_id)'
+    q += ' RIGHT JOIN users.bans b ON (u.id = b.user_id AND b.expiration > now())'
   }
   return db.sqlQuery(q)
   .then(function(rows) {


### PR DESCRIPTION
* Was counting all users with existing ban row, should have been
  limiting by b.expiration > now()