### PR TITLE
Board mapping

### DIFF
--- a/boards/index.js
+++ b/boards/index.js
@@ -12,7 +12,7 @@ var NotFoundError = Promise.OperationalError;
 var using = Promise.using;
 
 boards.all = function() {
-  return db.sqlQuery('SELECT id, parent_board_id, children_ids, category_id, name, description, created_at, updated_at, imported_at from boards')
+  return db.sqlQuery('SELECT id, name, description, created_at, updated_at, imported_at from boards')
   .then(helper.slugify);
 };
 
@@ -70,7 +70,7 @@ boards.update = function(board) {
     })
     .then(function() {
       q = 'UPDATE boards SET name = $1, description = $2, updated_at = now() WHERE id = $3';
-      params = [board.name, board.description, board.id];
+      params = [board.name, board.description || '', board.id];
       return client.queryAsync(q, params);
     });
   })
@@ -79,7 +79,7 @@ boards.update = function(board) {
 
 boards.find = function(id) {
   id = helper.deslugify(id);
-  var columns = 'b.id, b.parent_board_id, b.children_ids, b.category_id, b.name, b.description, b.created_at, b.updated_at, b.imported_at, mb.thread_count, mb.post_count';
+  var columns = 'b.id, b.name, b.description, b.created_at, b.updated_at, b.imported_at, mb.thread_count, mb.post_count';
   var q = 'SELECT ' + columns + ' FROM boards b ' +
     'LEFT JOIN metadata.boards mb ON b.id = mb.board_id WHERE b.id = $1';
   var params = [id];

--- a/helper.js
+++ b/helper.js
@@ -68,6 +68,7 @@ function slugTransform(input, slugMethod) {
     // iterate over each object key
     _.keys(input).map(function(key) {
       if (!input[key]) { return input[key]; }
+      if (key === 'id' && input[key] === -1) { return input[key]; }
 
       // check if key is candidate for (de)slugification
       if (_.contains(slugKeywords, key)) {

--- a/helper.js
+++ b/helper.js
@@ -5,7 +5,7 @@ var slugKeywords = [
   'board_id',
   'thread_id',
   'user_id',
-  'parent_board_id',
+  'parent_id',
   'category_id',
   'last_thread_id',
   'reporter_user_id',
@@ -68,7 +68,6 @@ function slugTransform(input, slugMethod) {
     // iterate over each object key
     _.keys(input).map(function(key) {
       if (!input[key]) { return input[key]; }
-      if (key === 'id' && input[key] === -1) { return input[key]; }
 
       // check if key is candidate for (de)slugification
       if (_.contains(slugKeywords, key)) {

--- a/migrations/20150617030235-board-mapping.js
+++ b/migrations/20150617030235-board-mapping.js
@@ -1,0 +1,28 @@
+var dbm = global.dbm || require('db-migrate');
+var type = dbm.dataType;
+var fs = require('fs');
+var path = require('path');
+
+exports.up = function(db, callback) {
+  var filePath = path.join(__dirname + '/sqls/20150617030235-board-mapping-up.sql');
+  fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+    if (err) return callback(err);
+
+    db.runSql(data, function(err) {
+      if (err) return callback(err);
+      callback();
+    });
+  });
+};
+
+exports.down = function(db, callback) {
+  var filePath = path.join(__dirname + '/sqls/20150617030235-board-mapping-down.sql');
+  fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+    if (err) return callback(err);
+
+    db.runSql(data, function(err) {
+      if (err) return callback(err);
+      callback();
+    });
+  });
+};

--- a/migrations/sqls/20150617030235-board-mapping-down.sql
+++ b/migrations/sqls/20150617030235-board-mapping-down.sql
@@ -1,0 +1,1 @@
+/* Replace with your SQL commands */

--- a/migrations/sqls/20150617030235-board-mapping-up.sql
+++ b/migrations/sqls/20150617030235-board-mapping-up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE board_mapping (
+  board_id uuid REFERENCES boards (id) ON UPDATE CASCADE ON DELETE CASCADE NOT NULL,
+  parent_id uuid REFERENCES boards (id) ON UPDATE CASCADE ON DELETE CASCADE,
+  category_id uuid REFERENCES categories (id) ON UPDATE CASCADE ON DELETE CASCADE,
+  view_order integer NOT NULL
+);
+CREATE INDEX index_board_mapping_on_board_id ON board_mapping USING btree (board_id);
+
+ALTER TABLE boards DROP COLUMN parent_board_id;
+ALTER TABLE boards DROP COLUMN children_ids;
+ALTER TABLE boards DROP COLUMN category_id;
+ALTER TABLE metadata.boards DROP COLUMN total_post_count;
+ALTER TABLE metadata.boards DROP COLUMN total_thread_count;


### PR DESCRIPTION
Added a new intersection table to list all the mappings between categories and boards and between parent boards and children boards. The boards.find method was also updated to return children boards. 

This pull request must be tested with the board-mapping branch in epochtalk/epochtalk.

To test this pull request, run the db-migration and update the category with boards. 
  * Create a new category and save
  * Create a new board and save
  * Create a new category and a new board and save
  * Nest boards at least two levels deep and save

Ensure that all changes are reflected on the front page and in board's page as well. Things to look out for: 
  * thread count and post count should exists and show count child counts as well
  * on a board's page, ensure that any children boards appear, along with said counts
  * board moderators are not implemented yet.
