### PR TITLE
Image expiration and post relations

### DIFF
--- a/images/index.js
+++ b/images/index.js
@@ -1,0 +1,53 @@
+var images = {};
+module.exports = images;
+
+var path = require('path');
+var db = require(path.join(__dirname, '..', 'db'));
+var helper = require(path.join(__dirname, '..', 'helper'));
+
+/* Image Expiration */
+
+images.addImageExpiration = function(url, expiration) {
+  var q = 'INSERT INTO image_expirations (image_url, expiration) VALUES ($1, $2)';
+  return db.sqlQuery(q, [url, expiration]);
+};
+
+images.clearImageExpiration = function(url) {
+  var q = 'DELETE FROM image_expirations WHERE image_url = $1';
+  return db.sqlQuery(q, [url]);
+};
+
+images.getExpiredImages = function() {
+  var q = 'SELECT image_url FROM image_expirations WHERE expiration < now()';
+  return db.sqlQuery(q);
+};
+
+/* Post Images */
+
+images.addPostImage = function(postId, url) {
+  postId = helper.deslugify(postId);
+  var q = 'INSERT INTO images_posts (image_url, post_id) VALUES ($1, $2)';
+  return db.sqlQuery(q, [url, postId]);
+};
+
+images.removePostImages = function(postId) {
+  postId = helper.deslugify(postId);
+  var q = 'UPDATE images_posts SET post_id = NULL WHERE post_id = $1';
+  return db.sqlQuery(q, [postId]);
+};
+
+images.getDeletedPostImages = function() {
+  var q = 'SELECT id, image_url FROM images_posts WHERE post_id IS NULL';
+  return db.sqlQuery(q).then(helper.slugify);
+};
+
+images.getImageReferences = function(url) {
+  var q = 'SELECT post_id FROM images_posts WHERE image_url = $1';
+  return db.sqlQuery(q, [url]).then(helper.slugify);
+};
+
+images.deleteImageReference = function(id) {
+  id = helper.deslugify(id);
+  var q = 'DELETE FROM images_posts WHERE id = $1';
+  return db.sqlQuery(q, [id]);
+};

--- a/index.js
+++ b/index.js
@@ -18,8 +18,9 @@ function core(opts) {
   core.posts = require(path.join(__dirname, 'posts'));
   core.threads = require(path.join(__dirname, 'threads'));
   core.reports = require(path.join(__dirname, 'reports'));
+  core.images = require(path.join(__dirname, 'images'));
   core.close = function() {
     pg.end();
   };
   return core;
-};
+}

--- a/migrations/20150725224651-images.js
+++ b/migrations/20150725224651-images.js
@@ -1,0 +1,28 @@
+var dbm = global.dbm || require('db-migrate');
+var type = dbm.dataType;
+var fs = require('fs');
+var path = require('path');
+
+exports.up = function(db, callback) {
+  var filePath = path.join(__dirname + '/sqls/20150725224651-images-up.sql');
+  fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+    if (err) return callback(err);
+
+    db.runSql(data, function(err) {
+      if (err) return callback(err);
+      callback();
+    });
+  });
+};
+
+exports.down = function(db, callback) {
+  var filePath = path.join(__dirname + '/sqls/20150725224651-images-down.sql');
+  fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+    if (err) return callback(err);
+
+    db.runSql(data, function(err) {
+      if (err) return callback(err);
+      callback();
+    });
+  });
+};

--- a/migrations/sqls/20150725224651-images-down.sql
+++ b/migrations/sqls/20150725224651-images-down.sql
@@ -1,0 +1,1 @@
+/* Replace with your SQL commands */

--- a/migrations/sqls/20150725224651-images-up.sql
+++ b/migrations/sqls/20150725224651-images-up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE image_expirations (
+  expiration timestamp with time zone,
+  image_url text NOT NULL
+);
+CREATE INDEX index_image_expirations_on_expiration ON image_expirations (expiration);
+CREATE INDEX index_image_expirations_on_image_url ON image_expirations (image_url);
+
+CREATE TABLE images_posts (
+  id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,
+  post_id uuid REFERENCES posts (id) ON DELETE SET NULL,
+  image_url text NOT NULL
+);
+CREATE INDEX index_images_posts_on_post_id ON images_posts (post_id);
+CREATE INDEX index_images_posts_on_image_url ON images_posts (image_url);

--- a/posts/index.js
+++ b/posts/index.js
@@ -152,8 +152,8 @@ posts.update = function(post) {
     })
     .then(function(oldPost) {
       post.title = post.title || oldPost.title;
-      post.body = post.body || oldPost.body;
-      post.raw_body = post.raw_body || oldPost.raw_body;
+      helper.updateAssign(post, oldPost, post, 'body');
+      helper.updateAssign(post, oldPost, post, 'raw_body');
       post.thread_id = post.thread_id || oldPost.thread_id;
     })
     .then(function() {


### PR DESCRIPTION
The image expiration table has been moved from memdown on the server
side to postgres at the DB layer. This allows for the persistents of
images expirations.

A new table called images_posts was also created to log images are being
reference in all posts. This allows the frontend to query for images not
being used anymore and removes them from the cdn of choice.

To be tested with the branch of the same name in epochtalk/epochtalk