### PR TITLE
Private Messages

### DIFF
--- a/conversations/index.js
+++ b/conversations/index.js
@@ -1,0 +1,101 @@
+var conversations = {};
+module.exports = conversations;
+
+var path = require('path');
+var Promise = require('bluebird');
+var db = require(path.join(__dirname, '..', 'db'));
+var helper = require(path.join(__dirname, '..', 'helper'));
+var DeletionError = Promise.OperationalError;
+var CreationError = Promise.OperationalError;
+var using = Promise.using;
+
+conversations.create = function() {
+  var conversation = {};
+  var q = 'INSERT INTO private_conversations(created_at) VALUES (now()) RETURNING id, created_at';
+  return using(db.createTransaction(), function(client) {
+    return client.queryAsync(q)
+    .then(function(results) {
+      if (results.rows.length > 0) {
+        conversation.id = results.rows[0].id;
+        conversation.created_at = results.rows[0].created_at;
+      }
+      else { throw new CreationError('Private Conversation Could Not Be Saved'); }
+    });
+  })
+  .then(function() { return helper.slugify(conversation); });
+};
+
+conversations.messages = function(conversationId, viewerId, opts) {
+  conversationId = helper.deslugify(conversationId);
+  viewerId = helper.deslugify(viewerId);
+
+  opts = opts || {};
+  var limit = opts.limit || 15;
+  var timestamp = opts.timestamp || new Date();
+  var messageId = opts.messageId;
+  if (messageId) { messageId = helper.deslugify(messageId); }
+  var params = [conversationId, viewerId, timestamp, limit];
+
+  var columns = 'mid.id, mid.conversation_id, mid.sender_id, mid.receiver_id, mid.copied_ids, mid.body, mid.created_at, mid.viewed, s.username as sender_username, s.deleted as sender_deleted, s.avatar as sender_avatar, r.username as receiver_username, r.deleted as receiver_deleted, r.avatar as receiver_avatar';
+  var q = 'SELECT conversation_id, id, sender_id, receiver_id, copied_ids, body, created_at, viewed FROM private_messages WHERE conversation_id = $1 AND (sender_id = $2 OR receiver_id = $2) AND created_at <= $3';
+  var q2 = 'SELECT u.username, u.deleted, up.avatar FROM users u LEFT JOIN users.profiles up ON u.id = up.user_id WHERE u.id = mid.sender_id';
+  var q3 = 'SELECT u.username, u.deleted, up.avatar FROM users u LEFT JOIN users.profiles up ON u.id = up.user_id WHERE u.id = mid.receiver_id';
+
+  if (messageId) {
+    var withId = ' AND id != $4 ORDER BY created_at DESC LIMIT $5';
+    q = q + withId;
+    params = [conversationId, viewerId, timestamp, messageId, limit];
+  }
+  else { q = q + ' ORDER BY created_at DESC LIMIT $4'; }
+
+  var query = 'SELECT ' + columns + ' FROM ( ' +
+    q + ' ) mid LEFT JOIN LATERAL ( ' +
+    q2 + ' ) s ON true LEFT JOIN LATERAL ( ' +
+    q3 + ' ) r ON true';
+
+  // get all related posts
+  return db.sqlQuery(query, params)
+  // get user info for each copied user id
+  .map(function(message) {
+    message.copied = message.copied_ids.map(function(userId) {
+      var mapQuery = 'SELECT id, username, deleted, avatar FROM users WHERE id = $1';
+      return db.sqlQuery(q, userId)
+      .then(function(result) { return result[0]; });
+    });
+    delete message.copied_ids;
+    return message;
+  })
+  // reverse message listing
+  .then(function(messages) {
+    messages.reverse();
+    return messages;
+  })
+  .then(helper.slugify);
+};
+
+conversations.delete = function(id) {
+  id = helper.deslugify(id);
+
+  return using(db.createTransaction(), function(client) {
+    // Check if conversation exists
+    var q = 'SELECT id from private_conversations WHERE id = $1 FOR UPDATE';
+    return client.queryAsync(q, [id])
+    .then(function(results) {
+      if (results.rows.length < 1) { throw new DeletionError('Conversation Does Not Exist'); }
+    })
+    // delete the private conversation
+    .then(function() {
+      q = 'DELETE FROM private_conversations WHERE id = $1';
+      return client.queryAsync(q, [id]);
+    });
+  });
+};
+
+conversations.isConversationMember = function(conversationId, userId) {
+  conversationId = helper.deslugify(conversationId);
+  userId = helper.deslugify(userId);
+
+  var q = 'SELECT id FROM private_messages WHERE conversation_id = $1 AND (sender_id = $2 OR receiver_id = $2)';
+  return db.sqlQuery(q, [conversationId, userId])
+  .then(function(rows) { return rows.length > 0; });
+};

--- a/helper.js
+++ b/helper.js
@@ -15,9 +15,12 @@ var slugKeywords = [
   'offender_thread_id',
   'offender_author_id',
   'report_id',
-  'status_id'
+  'status_id',
+  'conversation_id',
+  'sender_id',
+  'receiver_id',
 ];
-var slugArrayKeywords = ['children_ids', 'board_ids'];
+var slugArrayKeywords = ['children_ids', 'board_ids', 'copied_ids'];
 
 module.exports = {
   intToUUID: function(id) {

--- a/index.js
+++ b/index.js
@@ -19,8 +19,8 @@ function core(opts) {
   core.threads = require(path.join(__dirname, 'threads'));
   core.reports = require(path.join(__dirname, 'reports'));
   core.images = require(path.join(__dirname, 'images'));
-  core.close = function() {
-    pg.end();
-  };
+  core.messages = require(path.join(__dirname, 'messages'));
+  core.conversations = require(path.join(__dirname, 'conversations'));
+  core.close = function() { pg.end(); };
   return core;
 }

--- a/messages/index.js
+++ b/messages/index.js
@@ -1,0 +1,123 @@
+var messages = {};
+module.exports = messages;
+
+var path = require('path');
+var Promise = require('bluebird');
+var db = require(path.join(__dirname, '..', 'db'));
+var helper = require(path.join(__dirname, '..', 'helper'));
+var DeletionError = Promise.OperationalError;
+var CreationError = Promise.OperationalError;
+var NotFoundError = Promise.OperationalError;
+var using = Promise.using;
+
+messages.create = function(message) {
+  message = helper.deslugify(message);
+  var q = 'INSERT INTO private_messages(conversation_id, sender_id, receiver_id, copied_ids, body, created_at) VALUES ($1, $2, $3, $4, $5, now()) RETURNING id, created_at';
+  var params = [message.conversation_id, message.sender_id, message.receiver_id, message.copied_ids || [], message.body];
+  return using(db.createTransaction(), function(client) {
+    return client.queryAsync(q, params)
+    .then(function(results) {
+      if (results.rows.length > 0) {
+        message.id = results.rows[0].id;
+        message.created_at = results.rows[0].created_at;
+        message.viewed = false;
+      }
+      else { throw new CreationError('Private Message Could Not Be Saved'); }
+    });
+  })
+  .then(function() { return helper.slugify(message); });
+};
+
+messages.latest = function(userId, opts) {
+  userId = helper.deslugify(userId);
+  opts = opts || {};
+
+  var columns = 'mid.id, mid.conversation_id, mid.sender_id, mid.receiver_id, mid.copied_ids, mid.body, mid.created_at, mid.viewed, s.username as sender_username, s.deleted as sender_deleted, s.avatar as sender_avatar, r.username as receiver_username, r.deleted as receiver_deleted, r.avatar as receiver_avatar';
+  var q = ' SELECT * FROM ( SELECT DISTINCT ON (conversation_id) conversation_id, id, sender_id, receiver_id, copied_ids, body, created_at, viewed FROM private_messages WHERE sender_id = $1 OR receiver_id = $1 ORDER BY conversation_id, created_at DESC ) AS m ORDER BY m.created_at DESC LIMIT $2 OFFSET $3';
+  var q2 = 'SELECT u.username, u.deleted, up.avatar FROM users u LEFT JOIN users.profiles up ON u.id = up.user_id WHERE u.id = mid.sender_id';
+  var q3 = 'SELECT u.username, u.deleted, up.avatar FROM users u LEFT JOIN users.profiles up ON u.id = up.user_id WHERE u.id = mid.receiver_id';
+  var query = 'SELECT ' + columns + ' FROM ( ' +
+    q + ' ) mid LEFT JOIN LATERAL ( ' +
+    q2 + ' ) s ON true LEFT JOIN LATERAL ( ' +
+    q3 + ' ) r ON true';
+
+  var limit = 15;
+  var page = 1;
+  if (opts.limit) { limit = opts.limit; }
+  if (opts.page) { page = opts.page; }
+  var offset = (page * limit) - limit;
+
+  // get all related posts
+  var params = [userId, limit, offset];
+  return db.sqlQuery(query, params)
+  // get user info for each copied user id
+  .map(function(message) {
+    message.copied = message.copied_ids.map(function(userId) {
+      var mapQuery = 'SELECT id, username, deleted, avatar FROM users WHERE id = $1';
+      return db.sqlQuery(q, userId)
+      .then(function(result) { return result[0]; });
+    });
+    delete message.copied_ids;
+    return message;
+  })
+  .then(helper.slugify);
+};
+
+messages.delete = function(id) {
+  id = helper.deslugify(id);
+  var conversationId = '';
+
+  return using(db.createTransaction(), function(client) {
+    // Check if message exists
+    var q = 'SELECT conversation_id from private_messages WHERE id = $1 FOR UPDATE';
+    return client.queryAsync(q, [id])
+    .then(function(results) {
+      if (results.rows.length < 1) { throw new DeletionError('Message Does Not Exist'); }
+      else { conversationId = results.rows[0].conversation_id; }
+    })
+    // delete the private message
+    .then(function() {
+      q = 'DELETE FROM private_messages WHERE id = $1';
+      return client.queryAsync(q, [id]);
+    })
+    // clean up conversation if no more messages
+    .then(function() {
+      q = 'SELECT id FROM private_messages WHERE conversation_id = $1';
+      return client.queryAsync(q, [conversationId])
+      .then(function(results) {
+        if (results.rows.length < 1) {
+          q = 'DELETE FROM private_conversations WHERE id = $1';
+          client.queryAsync(q, [conversationId]);
+        }
+      });
+    });
+  });
+};
+
+messages.findUser = function(username, limit) {
+  var q = 'SELECT id, username FROM users WHERE username LIKE $1 ORDER BY username LIMIT $2';
+  return db.sqlQuery(q, [username + '%', limit || 25])
+  .then(helper.slugify);
+};
+
+messages.isMessageSender = function(messageId, userId) {
+  messageId = helper.deslugify(messageId);
+  userId = helper.deslugify(userId);
+
+  var q = 'SELECT sender_id FROM private_messages WHERE id = $1';
+  return db.sqlQuery(q, [messageId])
+  .then(function(rows) {
+    if (rows.length > 0) { return rows[0]; }
+    else { throw new NotFoundError('Message Not Found'); }
+  })
+  .then(function(message) { return message.sender_id === userId; });
+};
+
+messages.conversationCount = function(userId) {
+  userId = helper.deslugify(userId);
+
+  // count conversations by this user
+  var q = 'SELECT DISTINCT ON (conversation_id) conversation_id FROM private_messages WHERE sender_id = $1 OR receiver_id = $1';
+  return db.sqlQuery(q, [userId])
+  .then(function(rows) { return rows.length; });
+};

--- a/migrations/20150806223158-private-messages.js
+++ b/migrations/20150806223158-private-messages.js
@@ -1,0 +1,28 @@
+var dbm = global.dbm || require('db-migrate');
+var type = dbm.dataType;
+var fs = require('fs');
+var path = require('path');
+
+exports.up = function(db, callback) {
+  var filePath = path.join(__dirname + '/sqls/20150806223158-private-messages-up.sql');
+  fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+    if (err) return callback(err);
+
+    db.runSql(data, function(err) {
+      if (err) return callback(err);
+      callback();
+    });
+  });
+};
+
+exports.down = function(db, callback) {
+  var filePath = path.join(__dirname + '/sqls/20150806223158-private-messages-down.sql');
+  fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+    if (err) return callback(err);
+
+    db.runSql(data, function(err) {
+      if (err) return callback(err);
+      callback();
+    });
+  });
+};

--- a/migrations/sqls/20150806223158-private-messages-down.sql
+++ b/migrations/sqls/20150806223158-private-messages-down.sql
@@ -1,0 +1,1 @@
+/* Replace with your SQL commands */

--- a/migrations/sqls/20150806223158-private-messages-up.sql
+++ b/migrations/sqls/20150806223158-private-messages-up.sql
@@ -1,0 +1,19 @@
+CREATE TABLE private_conversations (
+  id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,
+  created_at timestamp with time zone
+);
+
+CREATE TABLE private_messages (
+  id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,
+  conversation_id uuid NOT NULL REFERENCES private_conversations (id) ON DELETE CASCADE,
+  sender_id uuid REFERENCES users (id) ON DELETE CASCADE,
+  receiver_id uuid REFERENCES users (id) ON DELETE CASCADE,
+  copied_ids uuid[],
+  body text DEFAULT '' NOT NULL,
+  created_at timestamp with time zone,
+  viewed boolean DEFAULT false
+);
+CREATE INDEX index_conversation_id_on_private_messages ON private_messages (conversation_id);
+CREATE INDEX index_sender_id_on_private_messages ON private_messages (sender_id);
+CREATE INDEX index_receiver_id_on_private_messages ON private_messages (receiver_id);
+CREATE INDEX index_created_at_on_private_messages ON private_messages (created_at DESC);


### PR DESCRIPTION
A new migration was added that creates two tables in the database where
the conversation model and the private message model are being stored.

The necessary db methods were created to manipulate those tables. These
method include creating and deleting the models as well as retriving a
list of the most recent messages and the most recent message for any
given conversation. A few other helper methods were also created such as
a method that determines if a user is in a conversation or if a user is
the person that sent the message.

Testing Procedures:
- go to the messages view
- create a conversation
- create a message
- delete message
- delete last message in conversation
- ensure conversation no longer exists
- create more than 15 conversations
- create more than 15 message in one conversation
- ensure anchor scrolling works on conversation load
- ensure pagination works
- ensure conversations and message are sorted by created_at DESC

Must be test with the same branch name in epochtalk/epochtalk