### PR TITLE
Post history support

### DIFF
--- a/migrations/sqls/20150926015235-posts-history-up.sql
+++ b/migrations/sqls/20150926015235-posts-history-up.sql
@@ -5,3 +5,5 @@ CREATE TABLE posts_history (
   body text DEFAULT '' NOT NULL,
   created_at timestamp with time zone
 );
+
+CREATE INDEX index_posts_history_on_post_id ON posts_history USING btree (post_id);


### PR DESCRIPTION
Updates via posts.update will save the previously saved content in
posts_history sans title. Only posts with at least 1 revision will have
content referenced to the posts_history table.
