### PR TITLE
Moderate threads

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -2,7 +2,7 @@
 
 Run `db-migrate`
 
-`db-migrate create [migration_name] --sql-file`
+`db-migrate create [migration-name] --sql-file`
 
 Copy one of the old migrations javascript files to migrations/[file].js and
 specify the up and down files you've just generated though db-migrate.

--- a/migrations/20151202040710-self-mod.js
+++ b/migrations/20151202040710-self-mod.js
@@ -1,0 +1,28 @@
+var dbm = global.dbm || require('db-migrate');
+var type = dbm.dataType;
+var fs = require('fs');
+var path = require('path');
+
+exports.up = function(db, callback) {
+  var filePath = path.join(__dirname + '/sqls/20151202040710-self-mod-up.sql');
+  fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+    if (err) return callback(err);
+
+    db.runSql(data, function(err) {
+      if (err) return callback(err);
+      callback();
+    });
+  });
+};
+
+exports.down = function(db, callback) {
+  var filePath = path.join(__dirname + '/sqls/20151202040710-self-mod-down.sql');
+  fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+    if (err) return callback(err);
+
+    db.runSql(data, function(err) {
+      if (err) return callback(err);
+      callback();
+    });
+  });
+};

--- a/migrations/sqls/20151202040710-self-mod-down.sql
+++ b/migrations/sqls/20151202040710-self-mod-down.sql
@@ -1,0 +1,1 @@
+/* Replace with your SQL commands */

--- a/migrations/sqls/20151202040710-self-mod-up.sql
+++ b/migrations/sqls/20151202040710-self-mod-up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE threads ADD COLUMN moderated boolean DEFAULT false;

--- a/posts/index.js
+++ b/posts/index.js
@@ -313,7 +313,38 @@ posts.getThreadFirstPost = function(postId) {
   })
   .then(function(rows) {
     if (rows.length > 0 ) { return rows[0]; }
-    else { throw new NotFoundError('Thread Not Found'); }
+    else { throw new NotFoundError('First Post Not Found'); }
   })
   .then(helper.slugify);
+};
+
+posts.isPostsThreadModerated = function(postId) {
+  postId = helper.deslugify(postId);
+  var q = 'SELECT t.moderated FROM posts p LEFT JOIN threads t ON p.thread_id = t.id WHERE p.id = $1';
+  return db.sqlQuery(q, [postId])
+  .then(function(rows) {
+    if (rows.length > 0 ) { return rows[0]; }
+    else { throw new NotFoundError('Thread Not Found'); }
+  })
+  .then(function(thread) { return thread.moderated; });
+};
+
+posts.isPostsThreadOwner = function(postId, userId) {
+  postId = helper.deslugify(postId);
+  userId = helper.deslugify(userId);
+
+  var q = 'SELECT thread_id FROM posts WHERE id = $1';
+  return db.sqlQuery(q, [postId])
+  .then(function(rows) {
+    if (rows.length > 0) {
+      q = 'SELECT * FROM posts WHERE thread_id = $1 ORDER BY created_at LIMIT 1';
+      return db.sqlQuery(q, [rows[0].thread_id]);
+    }
+    else { throw new NotFoundError('Post Not Found'); }
+  })
+  .then(function(rows) {
+    if (rows.length > 0 ) { return rows[0]; }
+    else { throw new NotFoundError('First Post Not Found'); }
+  })
+  .then(function(post) { return post.user_id === userId; });
 };


### PR DESCRIPTION
Added a moderated flag on the thread db model that specifies if the thread is allowed to be moderated by the thread creator. All db migrations and updates to db methods included.

Refer to the branch of the same name on epochtalk/epochtalk for testing procedures.